### PR TITLE
Update workflow to use artifact actions v4, update actions/cache from…

### DIFF
--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -55,4 +55,3 @@ jobs:
           path: test/cookbooks/Win10MySQLOverlay/*-results.json
           if-no-files-found: error
           name: ${{ matrix.suite }}-results
-          overwrite: true

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -54,3 +54,5 @@ jobs:
         with:
           path: test/cookbooks/Win10MySQLOverlay/*-results.json
           if-no-files-found: error
+          name: ${{ matrix.suite }}-results
+          overwrite: true

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
       - name: Setup caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -50,7 +50,7 @@ jobs:
           cd test/cookbooks/Win10MySQLOverlay/
           bundle exec inspec_tools summary -j ${{ matrix.suite }}-test-results.json --json-counts | jq .
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: test/cookbooks/Win10MySQLOverlay/*-results.json
           if-no-files-found: error


### PR DESCRIPTION
… v2 to v4, and replaced archived actions/setup-ruby with ruby/setup-ruby

Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Also actions/setup-ruby is archived and has been recommended instead to use ruby/setup-ruby
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)